### PR TITLE
Fix: Align AJAX 'load more companies' URL with clean URL structure

### DIFF
--- a/templates/companies/index.php
+++ b/templates/companies/index.php
@@ -133,7 +133,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if(loadingIndicator) loadingIndicator.style.display = 'block';
 
         // Corrected AJAX URL construction
-        let ajaxUrl = `companies/route=companies&action=load_more_companies&page=${currentPage}&ajax=1`;
+        let ajaxUrl = `companies/load_more_companies?page=${currentPage}&ajax=1`;
         if (currentSearchTerm) {
             ajaxUrl += `&search_query=${encodeURIComponent(currentSearchTerm)}`;
         }


### PR DESCRIPTION
The AJAX request URL for loading more companies was previously not correctly formatted for the project's clean URL setup. This could lead to the server returning HTML instead of JSON, causing client-side parsing errors.

This commit updates the JavaScript in `templates/companies/index.php` to construct the AJAX URL in the format `companies/load_more_companies?param=value...`. This ensures that the request is correctly routed by the server (via .htaccess and `public/index.php`) to the appropriate PHP handler, which then returns a valid JSON response.

This approach supersedes a previous attempt that incorrectly re-introduced 'index.php?' into the URL.