### PR TITLE
feat: Implement search-as-you-type suggestions for company search

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -886,3 +886,40 @@ footer p {
      margin-right: 4px;
      font-size: 1.5em; /* Larger for headings */
 }
+
+/* Search Suggestions Styles */
+.sidebar-search {
+    position: relative; /* Context for absolute positioning of suggestions */
+}
+
+#search-suggestions-container {
+    position: absolute;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-top: none;
+    z-index: 1000;
+    width: auto; /* Auto width by default */
+    max-height: 300px;
+    overflow-y: auto;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    left: 0;
+    right: 0; /* Makes it take full width of the relative parent .sidebar-search */
+    top: 100%; /* Position it right below the natural end of the parent (input field) */
+}
+
+.suggestion-item {
+    display: block;
+    padding: 8px 12px;
+    color: #333;
+    text-decoration: none;
+    cursor: pointer;
+    border-bottom: 1px solid #eee;
+}
+
+.suggestion-item:last-child {
+    border-bottom: none;
+}
+
+.suggestion-item:hover {
+    background-color: #f5f5f5;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -405,6 +405,17 @@ switch ($page) {
                 echo json_encode($response_data);
                 exit;
 
+            case 'search_suggestions':
+                header('Content-Type: application/json');
+                $query = $_GET['query'] ?? '';
+                if (empty($query)) {
+                    echo json_encode([]);
+                    exit;
+                }
+                $suggestions = $companyManager->searchSuggestions($query);
+                echo json_encode($suggestions);
+                exit;
+
             default:
                 $search_query = $_GET['search_query'] ?? null;
                 // Fetch page 1, limit 100 for initial company list view

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,4 +1,13 @@
 document.addEventListener('DOMContentLoaded', function() {
+    function debounce(func, delay) {
+        let timeout;
+        return function(...args) {
+            const context = this;
+            clearTimeout(timeout);
+            timeout = setTimeout(() => func.apply(context, args), delay);
+        };
+    }
+
     // Get elements
     const sidebarToggles = document.querySelectorAll('.sidebar-toggle');
     const sidebar = document.querySelector('.sidebar');
@@ -44,4 +53,59 @@ document.addEventListener('DOMContentLoaded', function() {
     //         }
     //     });
     // });
+
+    // Search suggestions logic
+    const searchInput = document.getElementById('search-input');
+    const suggestionsContainer = document.getElementById('search-suggestions-container');
+
+    if (searchInput && suggestionsContainer) {
+        searchInput.addEventListener('input', debounce(async function() {
+            const query = searchInput.value.trim();
+            suggestionsContainer.innerHTML = ''; // Clear previous suggestions
+
+            if (query.length > 1) {
+                try {
+                    const response = await fetch(`companies/search_suggestions?query=${encodeURIComponent(query)}`);
+                    if (!response.ok) {
+                        // Handle HTTP errors, e.g., response.status
+                        console.error('Search suggestions fetch error:', response.status);
+                        return;
+                    }
+                    const data = await response.json();
+
+                    if (data && data.length > 0) {
+                        data.forEach(suggestion => {
+                            const a = document.createElement('a');
+                            a.textContent = suggestion.pavadinimas;
+                            a.href = '#'; // Prevent navigation, action handled by click listener
+                            a.classList.add('suggestion-item'); // For styling
+
+                            a.addEventListener('click', function(e) {
+                                e.preventDefault(); // Prevent default anchor action
+                                searchInput.value = suggestion.pavadinimas;
+                                suggestionsContainer.innerHTML = '';
+                                if (searchInput.form) {
+                                    searchInput.form.submit();
+                                }
+                            });
+                            suggestionsContainer.appendChild(a);
+                        });
+                    } else {
+                        // No suggestions found, could display a message if desired
+                        // suggestionsContainer.innerHTML = '<div class="suggestion-item-none">No suggestions found.</div>';
+                    }
+                } catch (error) {
+                    console.error('Error fetching search suggestions:', error);
+                    // Optionally display an error message in the suggestionsContainer
+                }
+            }
+        }, 300));
+
+        // Handle clicking outside to close suggestions
+        document.addEventListener('click', function(event) {
+            if (!suggestionsContainer.contains(event.target) && event.target !== searchInput) {
+                suggestionsContainer.innerHTML = '';
+            }
+        });
+    }
 });

--- a/src/classes/Company.php
+++ b/src/classes/Company.php
@@ -387,6 +387,19 @@ class Company
 
     }
 
+    public function searchSuggestions(string $query): array
+    {
+        $sql = "SELECT id, pavadinimas FROM " . $this->companiesTable . " WHERE pavadinimas LIKE :query LIMIT 10";
+        try {
+            $this->db->query($sql);
+            $this->db->bind(':query', '%' . $query . '%');
+            return $this->db->resultSet();
+        } catch (PDOException $e) {
+            // Log error, but return empty array to the client
+            error_log("Error searching suggestions: " . $e->getMessage());
+            return [];
+        }
+    }
 }
 
 ?>

--- a/templates/layout/header.php
+++ b/templates/layout/header.php
@@ -39,8 +39,9 @@ $currentAction = $_GET['action'] ?? '';
         </div>
         <div class="sidebar-search">
             <form action="<?php echo url('companies'); ?>" method="GET">
-                <input type="text" name="search_query" placeholder="Ieškoti įmonės..." value="<?php echo isset($_GET['search_query']) ? e($_GET['search_query']) : ''; ?>">
+                <input type="text" name="search_query" id="search-input" placeholder="Ieškoti įmonės..." value="<?php echo isset($_GET['search_query']) ? e($_GET['search_query']) : ''; ?>">
             </form>
+            <div id="search-suggestions-container"></div>
         </div>
         <nav class="sidebar-nav">
             <ul>


### PR DESCRIPTION
This commit introduces a search-as-you-type feature for the company search functionality. As you type into the search bar, suggestions are dynamically fetched and displayed below the input field.

Key changes include:

- Added a new PHP endpoint (`companies/search_suggestions`) that queries the database for company names matching the input and returns them as JSON.
- Modified the search input in the header (`templates/layout/header.php`) to include an ID for JavaScript targeting and a container for the suggestions.
- Implemented client-side JavaScript (`public/js/script.js`) to:
    - Listen for input in the search field.
    - Debounce AJAX requests to the suggestions endpoint.
    - Display fetched suggestions.
    - Allow you to click a suggestion to populate the search field and submit the search form.
    - Handle clicks outside the suggestions list to close it.
- Added CSS styles (`public/css/style.css`) to position and style the suggestions dropdown appropriately.

This enhancement aims to improve your experience by making the search process faster and more intuitive.