### PR TITLE
feat: Display company count in footer and make tables scrollable

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -923,3 +923,13 @@ footer p {
 .suggestion-item:hover {
     background-color: #f5f5f5;
 }
+
+.table-responsive-wrapper {
+    overflow-x: auto;
+    width: 100%; /* Ensures the wrapper takes full available width */
+}
+
+/* Optional: Style for tables within the wrapper to ensure they don't try to shrink unnaturally */
+.table-responsive-wrapper table {
+    min-width: 100%; /* Or a specific min-width like 600px if tables have a natural minimum size */
+}

--- a/public/index.php
+++ b/public/index.php
@@ -36,6 +36,7 @@ try {
 
 $auth = new Auth($db);
 $companyManager = new Company($db);
+$view_data['total_companies'] = $companyManager->getTotalCompaniesCount();
 
 $view_data = [];
 $view_template = 'home.php';

--- a/src/classes/Company.php
+++ b/src/classes/Company.php
@@ -98,6 +98,19 @@ class Company
 
     }
 
+    public function getTotalCompaniesCount(): int
+    {
+        try {
+            $sql = "SELECT COUNT(*) as total FROM " . $this->companiesTable;
+            $this->db->query($sql);
+            $result = $this->db->single();
+            return (int)($result['total'] ?? 0);
+        } catch (PDOException $e) {
+            error_log("Error getting total companies count: " . $e->getMessage());
+            return 0;
+        }
+    }
+
 
 
     /**

--- a/templates/layout/footer.php
+++ b/templates/layout/footer.php
@@ -7,6 +7,7 @@
 
 <footer>
     <p>&copy; <?php echo date('Y'); ?> Rekvizitų Valdymo Sistema. <?php echo "Šiuo metu yra: " . date("Y-m-d H:i:s"); ?> (EEST)</p>
+    <p>Viso įmonių sistemoje: <?php echo $view_data['total_companies'] ?? 0; ?>.</p>
 </footer>
 <script src="/js/script.js"></script>
 </body>


### PR DESCRIPTION
- Added a method to Company.php to get the total count of companies.
- Updated index.php to fetch this count and pass it to views.
- Modified footer.php to display the total company count.
- Added CSS for .table-responsive-wrapper to make tables horizontally scrollable if they overflow, preventing page layout breakage.

This addresses your request to show the number of companies and to fix table layout issues on smaller screens.