### PR TITLE
fix: Correct company count display in footer

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -38,7 +38,6 @@ $auth = new Auth($db);
 $companyManager = new Company($db);
 $view_data['total_companies'] = $companyManager->getTotalCompaniesCount();
 
-$view_data = [];
 $view_template = 'home.php';
 
 // Initialize with defaults

--- a/src/classes/Company.php
+++ b/src/classes/Company.php
@@ -100,13 +100,25 @@ class Company
 
     public function getTotalCompaniesCount(): int
     {
+        $sql = ""; // Initialize for logging in case of early failure
         try {
             $sql = "SELECT COUNT(*) as total FROM " . $this->companiesTable;
-            $this->db->query($sql);
-            $result = $this->db->single();
-            return (int)($result['total'] ?? 0);
-        } catch (PDOException $e) {
-            error_log("Error getting total companies count: " . $e->getMessage());
+            $this->db->query($sql); // Prepares the query
+            $result = $this->db->single(); // Executes and fetches
+
+            // Check if $result is an array and if 'total' key exists
+            if (is_array($result) && isset($result['total'])) {
+                return (int)$result['total'];
+            } else {
+                // Log this specific scenario for better debugging
+                error_log("Error getting total companies count: db->single() did not return expected array or 'total' key was missing. SQL: " . $sql . ". Result from db->single(): " . print_r($result, true));
+                return 0;
+            }
+        } catch (PDOException $e) { // Catches exceptions from query preparation (from $this->db->query())
+            error_log("PDOException in getTotalCompaniesCount: " . $e->getMessage() . " | SQL: " . $sql);
+            return 0;
+        } catch (Exception $e) { // Catch any other unexpected non-PDO errors
+            error_log("Generic Exception in getTotalCompaniesCount: " . $e->getMessage() . " | SQL: " . $sql);
             return 0;
         }
     }


### PR DESCRIPTION
The company count was previously always showing as 0 due to the `$view_data` array being reset in `public/index.php` after the count was fetched and stored. This commit removes the erroneous reset of `$view_data`.

Additionally, the `getTotalCompaniesCount` method in `Company.php` has been enhanced with more robust error checking and detailed logging to aid in diagnosing any underlying database query issues if the problem were to persist.