### PR TITLE
fix: Correct URL format for AJAX-loaded company links

### DIFF
--- a/templates/companies/index.php
+++ b/templates/companies/index.php
@@ -90,14 +90,14 @@ document.addEventListener('DOMContentLoaded', function () {
     const currentSearchTerm = <?php echo json_encode($search_query_active ?? null); ?>;
     // Function to generate URL (approximating the PHP url() function)
     function siteUrl(controller, action = '', id = 0) {
-        let path = `companies/route=${controller}`;
+        let path = '/' + controller; // Start with a leading slash for root-relative URLs
         if (action) {
-            path += `&action=${action}`;
+            path += '/' + action;
         }
-        if (id) {
-            path += `&id=${id}`;
+        if (id) { // Only add ID if action is also present, or handle cases based on PHP logic
+            path += '/' + id;
         }
-        return path; // Adjust this base path if your URL structure is different (e.g., using mod_rewrite)
+        return path;
     }
 
     // Function to escape HTML (approximating PHP e() function)


### PR DESCRIPTION
The JavaScript `siteUrl` function used for generating links for companies loaded via infinite scroll (AJAX) was producing URLs with a query parameter format (e.g., companies/route=companies&action=view&id=ID). This was inconsistent with the path-based URLs generated by PHP for initially loaded companies (e.g., /companies/view/ID).

This commit updates the JavaScript `siteUrl` function in `templates/companies/index.php` to construct path-based URLs that match the format generated by the PHP `url()` helper function. This ensures consistent URL structure and correct navigation for all company links, whether loaded initially or via AJAX.