### PR TITLE
feat: Implement dynamic meta tags for company view pages

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -274,6 +274,30 @@ switch ($page) {
                     redirect('companies');
                 }
                 $view_data['company'] = $company;
+                if ($company) {
+                    $view_data['meta_title'] = e($company['pavadinimas']) . ' - Rekvizitai'; // Dynamic title
+
+                    // Construct a meta description
+                    $description_parts = [];
+                    if (!empty($company['pavadinimas'])) {
+                        $description_parts[] = "Įmonės " . e($company['pavadinimas']) . " rekvizitai.";
+                    }
+                    if (!empty($company['adresas_gatve'])) {
+                        $description_parts[] = e($company['adresas_gatve']);
+                    }
+                    if (!empty($company['adresas_miestas'])) {
+                        $description_parts[] = e($company['adresas_miestas']);
+                    }
+                    if (!empty($company['imones_kodas'])) {
+                        $description_parts[] = "Įmonės kodas: " . e($company['imones_kodas']);
+                    }
+                    // Join parts, ensuring not too long. Limit to around 160 chars.
+                    $meta_desc_full = implode(', ', $description_parts);
+                    if (mb_strlen($meta_desc_full) > 160) {
+                        $meta_desc_full = mb_substr($meta_desc_full, 0, 157) . '...';
+                    }
+                    $view_data['meta_description'] = $meta_desc_full;
+                }
                 $view_template = 'companies/view.php';
                 break;
 

--- a/templates/layout/header.php
+++ b/templates/layout/header.php
@@ -13,7 +13,8 @@ $currentAction = $_GET['action'] ?? '';
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Rekvizitų Valdymo Sistema</title>
+    <title><?php echo isset($view_data['meta_title']) ? e($view_data['meta_title']) : 'Rekvizitų Valdymo Sistema'; ?></title>
+    <meta name="description" content="<?php echo isset($view_data['meta_description']) ? e($view_data['meta_description']) : 'Patogi įmonių rekvizitų paieškos ir valdymo sistema.'; ?>">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link rel="stylesheet" href="/css/style.css"> <?php // Root-relative path ensures CSS loads on all pages ?>
 </head>


### PR DESCRIPTION
This commit introduces SEO improvements by adding dynamic meta tags (title and description) to individual company view pages.

Changes:
- In `public/index.php`, when viewing a single company, `$view_data['meta_title']` and `$view_data['meta_description']` are now populated using the specific company's details. The description is a concatenation of key company information and is truncated to an appropriate length.
- `templates/layout/header.php` has been updated to use `$view_data['meta_title']` and `$view_data['meta_description']` for the `<title>` and `<meta name="description">` tags respectively, when these variables are available. If not, it falls back to default site-wide values.

This enhancement helps search engines better understand the content of individual company pages, improving their potential for indexing and ranking in search results.