### PR TITLE
Refactor admin panel and sitemap generation

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -933,3 +933,15 @@ footer p {
 .table-responsive-wrapper table {
     min-width: 100%; /* Or a specific min-width like 600px if tables have a natural minimum size */
 }
+
+/* Add this at the end of your public/css/style.css file */
+
+.sidebar-nav ul li.sidebar-nav-separator {
+    padding: 10px 15px;
+    margin-top: 10px;
+    font-weight: bold;
+    color: #888; /* Or your desired color */
+    background-color: #f0f0f0; /* Optional: a light background for the separator */
+    border-top: 1px solid #ddd; /* Optional: a top border */
+    border-bottom: 1px solid #ddd; /* Optional: a bottom border */
+}

--- a/public/index.php
+++ b/public/index.php
@@ -465,28 +465,37 @@ switch ($page) {
         $admin_action = $action ?? 'dashboard';
 
         switch ($admin_action) {
-            case 'generate_sitemap':
+            case 'sitemap': // This case now just displays the sitemap page
                 $auth->requireAdmin();
-                $sitemapGenerator = new SitemapGenerator($db, SITE_BASE_URL);
-                if ($sitemapGenerator->generate()) {
-                    set_flash_message('success_message', 'Sitemap failai (indeksas ir dalys) sėkmingai sugeneruoti!');
+                $view_template = 'admin/sitemap.php';
+                break;
+
+            case 'generate_sitemap_action': // This case handles the actual generation
+                $auth->requireAdmin();
+                if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                    $sitemapGenerator = new SitemapGenerator($db, SITE_BASE_URL);
+                    if ($sitemapGenerator->generate()) {
+                        set_flash_message('sitemap_success', 'Sitemap failai (indeksas ir dalys) sėkmingai sugeneruoti!');
+                    } else {
+                        set_flash_message('sitemap_error', 'Klaida generuojant sitemap failus.');
+                    }
                 } else {
-                    set_flash_message('error_message', 'Klaida generuojant sitemap failus.');
+                    // Should not be accessed via GET
+                    set_flash_message('sitemap_error', 'Netinkamas užklausos metodas sitemap generavimui.');
                 }
-                redirect('admin', 'users');
+                redirect('admin', 'sitemap'); // Redirect back to the sitemap page to show messages
                 break;
             case 'users':
                 $view_data['users'] = $auth->getAllUsers();
                 $view_template = 'admin/users_list.php';
                 break;
-                // case 'dashboard':
+            case 'dashboard':
+                $view_template = 'admin/dashboard.php';
+                break;
             default:
-                // For now, if no specific admin action, or it's 'dashboard',
-                // redirect to home or show a simple admin dashboard.
-                // $view_template = 'admin/dashboard.php';
-                // Decided to redirect to home if no specific admin action is matched for now.
-                set_flash_message('info_message', 'Pasirinkite veiksmą administratoriaus skydelyje.');
-                redirect('home'); // Or 'admin/dashboard' if you create that page.
+                // If no specific admin action is matched, or if it's an unknown action,
+                // redirect to the admin dashboard.
+                redirect('admin', 'dashboard');
                 break;
         }
         break;

--- a/templates/admin/dashboard.php
+++ b/templates/admin/dashboard.php
@@ -1,0 +1,15 @@
+<?php
+// templates/admin/dashboard.php
+
+// Page title
+$view_data['meta_title'] = 'Administratoriaus Skydelis';
+?>
+
+<h1>Administratoriaus Skydelis</h1>
+<p>Sveiki atvykę į administratoriaus skydelį. Čia galite valdyti įvairias svetainės funkcijas.</p>
+
+<div class="admin-actions">
+    <p><a href="<?php echo url('admin', 'users'); ?>" class="button">Vartotojų Sąrašas</a></p>
+    <p><a href="<?php echo url('companies', 'import'); ?>" class="button">Importuoti Įmones</a></p>
+    <p><a href="<?php echo url('admin', 'sitemap'); ?>" class="button">Sitemap Generavimas</a></p>
+</div>

--- a/templates/admin/sitemap.php
+++ b/templates/admin/sitemap.php
@@ -1,0 +1,32 @@
+<?php
+// templates/admin/sitemap.php
+
+// Page title
+$view_data['meta_title'] = 'Sitemap Generavimas';
+
+// Retrieve flash messages if any (passed from controller)
+$success_message = get_flash_message('sitemap_success');
+$error_message = get_flash_message('sitemap_error');
+
+?>
+
+<p><a href="<?php echo url('admin', 'dashboard'); ?>" class="button button-outline">&larr; Atgal į Administratoriaus Skydelį</a></p>
+
+<h1>Sitemap Generavimas</h1>
+
+<?php if ($success_message): ?>
+    <div class="alert alert-success"><?php echo e($success_message); ?></div>
+<?php endif; ?>
+
+<?php if ($error_message): ?>
+    <div class="alert alert-danger"><?php echo e($error_message); ?></div>
+<?php endif; ?>
+
+<p>Paspauskite mygtuką žemiau, kad sugeneruotumėte arba atnaujintumėte svetainės sitemap failus.</p>
+<p>Sitemap failai padeda paieškos sistemoms geriau indeksuoti jūsų svetainės turinį.</p>
+
+<form action="<?php echo url('admin', 'generate_sitemap_action'); ?>" method="POST">
+    <button type="submit" class="button button-primary">Generuoti Sitemap</button>
+</form>
+
+<p style="margin-top: 20px;"><strong>Pastaba:</strong> Generavimo procesas gali užtrukti keletą akimirkų, priklausomai nuo svetainės dydžio.</p>

--- a/templates/admin/users_list.php
+++ b/templates/admin/users_list.php
@@ -1,3 +1,4 @@
+<p><a href="<?php echo url('admin', 'dashboard'); ?>" class="button button-outline">&larr; Atgal į Administratoriaus Skydelį</a></p>
 <?php
 // templates/admin/users_list.php
 /** @var array $view_data */

--- a/templates/layout/header.php
+++ b/templates/layout/header.php
@@ -50,8 +50,11 @@ $currentAction = $_GET['action'] ?? '';
                 <li><a href="<?php echo url('companies'); ?>" class="<?php echo ($currentPage === 'companies' && !in_array($currentAction, ['create', 'import'])) ? 'active' : ''; ?>">Įmonių sąrašas</a></li>
                 <li><a href="<?php echo url('companies', 'create'); ?>" class="<?php echo ($currentPage === 'companies' && $currentAction === 'create') ? 'active' : ''; ?>">Pridėti įmonę</a></li>
                 <?php if ($auth->isAdmin()): ?>
-                    <li><a href="<?php echo url('companies', 'import'); ?>" class="<?php echo ($currentPage === 'companies' && $currentAction === 'import') ? 'active' : ''; ?>">Importuoti įmones</a></li>
-                    <li><a href="<?php echo url('admin', 'users'); ?>" class="<?php echo ($currentPage === 'admin' && $currentAction === 'users') ? 'active' : ''; ?>">Vartotojų Sąrašas (Admin)</a></li>
+                    <li class="sidebar-nav-separator">Administratoriaus Skydelis</li>
+                    <li><a href="<?php echo url('admin', 'dashboard'); ?>" class="<?php echo ($currentPage === 'admin' && $currentAction === 'dashboard') ? 'active' : ''; ?>">Pagrindinis Skydelis</a></li>
+                    <li><a href="<?php echo url('admin', 'users'); ?>" class="<?php echo ($currentPage === 'admin' && $currentAction === 'users') ? 'active' : ''; ?>">Vartotojų Valdymas</a></li>
+                    <li><a href="<?php echo url('companies', 'import'); ?>" class="<?php echo ($currentPage === 'companies' && $currentAction === 'import') ? 'active' : ''; ?>">Importuoti Įmones</a></li>
+                    <li><a href="<?php echo url('admin', 'sitemap'); ?>" class="<?php echo ($currentPage === 'admin' && $currentAction === 'sitemap') ? 'active' : ''; ?>">Sitemap Generavimas</a></li>
                 <?php endif; ?>
             </ul>
         </nav>


### PR DESCRIPTION
This commit introduces a new admin dashboard and refactors the sitemap generation functionality.

Key changes:
- Added a new admin dashboard page (`templates/admin/dashboard.php`) to serve as a central hub for admin tasks.
- Updated routing in `public/index.php` to support the new admin dashboard and make it the default admin landing page.
- Modified the sidebar navigation in `templates/layout/header.php`:
    - Added an "Admin Panel" section.
    - Grouped admin links (Users, Import Companies, Sitemap Generation) under this section.
- Created a dedicated page for sitemap generation (`templates/admin/sitemap.php`) with a form to trigger generation and display status messages.
- Updated `public/index.php` to handle the display of the sitemap page and the sitemap generation action separately.
- Added a link back to the admin dashboard from the user list page.
- Added a link to the sitemap generation page from the admin dashboard.