### PR TITLE
Fix admin panel UI issues

### DIFF
--- a/templates/companies/import_form.php
+++ b/templates/companies/import_form.php
@@ -1,3 +1,4 @@
+<p><a href="<?php echo url('admin', 'dashboard'); ?>" class="button button-outline">&larr; Atgal į Administratoriaus Skydelį</a></p>
 <?php
 // templates/companies/import_form.php
 $errors = $view_data['errors'] ?? [];

--- a/templates/layout/header.php
+++ b/templates/layout/header.php
@@ -51,7 +51,7 @@ $currentAction = $_GET['action'] ?? '';
                 <li><a href="<?php echo url('companies', 'create'); ?>" class="<?php echo ($currentPage === 'companies' && $currentAction === 'create') ? 'active' : ''; ?>">Pridėti įmonę</a></li>
                 <?php if ($auth->isAdmin()): ?>
                     <li class="sidebar-nav-separator">Administratoriaus Skydelis</li>
-                    <li><a href="<?php echo url('admin', 'dashboard'); ?>" class="<?php echo ($currentPage === 'admin' && $currentAction === 'dashboard') ? 'active' : ''; ?>">Pagrindinis Skydelis</a></li>
+                    <li><a href="<?php echo url('admin', 'dashboard'); ?>" class="<?php echo ($currentPage === 'admin' && ($currentAction === 'dashboard' || $currentAction === null || $currentAction === '')) ? 'active' : ''; ?>">Pagrindinis Skydelis</a></li>
                     <li><a href="<?php echo url('admin', 'users'); ?>" class="<?php echo ($currentPage === 'admin' && $currentAction === 'users') ? 'active' : ''; ?>">Vartotojų Valdymas</a></li>
                     <li><a href="<?php echo url('companies', 'import'); ?>" class="<?php echo ($currentPage === 'companies' && $currentAction === 'import') ? 'active' : ''; ?>">Importuoti Įmones</a></li>
                     <li><a href="<?php echo url('admin', 'sitemap'); ?>" class="<?php echo ($currentPage === 'admin' && $currentAction === 'sitemap') ? 'active' : ''; ?>">Sitemap Generavimas</a></li>


### PR DESCRIPTION
This commit addresses two UI issues in the admin panel:

1. Added a "Back to Admin Dashboard" link on the company import page (`templates/companies/import_form.php`) for easier navigation.
2. Fixed a bug in the sidebar menu (`templates/layout/header.php`) where the "Pagrindinis Skydelis" (Admin Dashboard) link was not correctly marked as active when it was the current page (e.g. when accessing /admin or /admin/). The active state logic for this link has been corrected.