### PR TITLE
feat: Initial Material Web PoC and setup

### DIFF
--- a/templates/auth/login_form.php
+++ b/templates/auth/login_form.php
@@ -19,17 +19,28 @@ $view_data['meta_title'] = trans('login_meta_title');
     <?php endif; ?>
 
     <form action="<?php echo url('login'); ?>" method="POST">
-        <div class="form-group">
-            <label for="username_or_email"><?php echo e(trans('username_or_email_label')); ?>:</label>
-            <input type="text" id="username_or_email" name="username_or_email" value="<?php echo e($form_values['username_or_email']); ?>" required>
-        </div>
+        <md-outlined-text-field
+            label="<?php echo e(trans('username_or_email_label')); ?>"
+            type="text"
+            id="username_or_email"
+            name="username_or_email"
+            value="<?php echo e($form_values['username_or_email']); ?>"
+            required
+            style="width: 100%; margin-bottom: 16px;">
+        </md-outlined-text-field>
 
-        <div class="form-group">
-            <label for="password"><?php echo e(trans('password_label')); ?>:</label>
-            <input type="password" id="password" name="password" required>
-        </div>
+        <md-outlined-text-field
+            label="<?php echo e(trans('password_label')); ?>"
+            type="password"
+            id="password"
+            name="password"
+            required
+            style="width: 100%; margin-bottom: 16px;">
+        </md-outlined-text-field>
 
-        <button type="submit" class="button button-primary"><?php echo e(trans('login_button')); ?></button>
+        <md-filled-button type="submit" style="width: 100%; --md-filled-button-container-shape: var(--md-sys-shape-corner-extra-small);">
+            <?php echo e(trans('login_button')); ?>
+        </md-filled-button>
     </form>
     <p class="auth-switch-prompt">
         <?php echo e(trans('dont_have_account')); ?>

--- a/templates/companies/index.php
+++ b/templates/companies/index.php
@@ -47,11 +47,17 @@ $view_data['meta_title'] = trans('companies_index_meta_title');
                             echo e(implode(', ', $address_parts));
                             ?>
                         </td>
-                        <td class="actions-cell">
-                            <a href="<?php echo url('companies', 'view', $company['id']); ?>" class="button button-small button-outline"><?php echo e(trans('view_action')); ?></a>
+                        <td class="actions-cell" style="display: flex; align-items: center; gap: 8px;">
+                            <md-outlined-button href="<?php echo url('companies', 'view', $company['id']); ?>">
+                                <?php echo e(trans('view_action')); ?>
+                            </md-outlined-button>
                             <?php if ($auth->isAdmin()): ?>
-                                <a href="<?php echo url('companies', 'edit', $company['id']); ?>" class="button button-small"><?php echo e(trans('edit_action')); ?></a>
-                                <a href="<?php echo url('companies', 'delete', $company['id']); ?>" class="button button-small button-danger"><?php echo e(trans('delete_action')); ?></a>
+                                <md-text-button href="<?php echo url('companies', 'edit', $company['id']); ?>">
+                                    <?php echo e(trans('edit_action')); ?>
+                                </md-text-button>
+                                <md-filled-button href="<?php echo url('companies', 'delete', $company['id']); ?>" style="--md-filled-button-container-color: var(--md-sys-color-error); --md-filled-button-label-text-color: var(--md-sys-color-on-error);">
+                                    <?php echo e(trans('delete_action')); ?>
+                                </md-filled-button>
                             <?php endif; ?>
                         </td>
                     </tr>
@@ -59,5 +65,7 @@ $view_data['meta_title'] = trans('companies_index_meta_title');
             </tbody>
         </table>
     </div>
-    <button id="load-more-companies" class="button" data-page="1" data-search-query="<?php echo e($search_query_active ?? ''); ?>"><?php echo e(trans('load_more_companies_button')); ?></button>
+    <md-filled-button id="load-more-companies" data-page="1" data-search-query="<?php echo e($search_query_active ?? ''); ?>">
+        <?php echo e(trans('load_more_companies_button')); ?>
+    </md-filled-button>
 <?php endif; ?>

--- a/templates/layout/header.php
+++ b/templates/layout/header.php
@@ -16,7 +16,20 @@ $currentAction = $view_data['current_action_resolved'] ?? '';
     <title><?php echo isset($view_data['meta_title']) ? e($view_data['meta_title']) : e(trans('site_title')); ?></title>
     <meta name="description" content="<?php echo isset($view_data['meta_description']) ? e($view_data['meta_description']) : e(trans('meta_description_default')); ?>">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/css/style.css"> <?php // Root-relative path ensures CSS loads on all pages ?>
+    <script type="importmap">
+      {
+        "imports": {
+          "@material/web/": "https://esm.run/@material/web/"
+        }
+      }
+    </script>
+    <script type="module">
+      import '@material/web/all.js';
+      import {styles as typescaleStyles} from '@material/web/typography/md-typescale-styles.js';
+      document.adoptedStyleSheets.push(typescaleStyles.styleSheet);
+    </script>
 </head>
 <body>
 <!-- Overlay for mobile menu -->
@@ -39,8 +52,14 @@ $currentAction = $view_data['current_action_resolved'] ?? '';
             </button>
         </div>
         <div class="sidebar-search">
-            <form action="<?php echo url('companies'); ?>" method="GET">
-                <input type="text" name="search_query" id="search-input" placeholder="<?php echo e(trans('search_placeholder')); ?>" value="<?php echo isset($_GET['search_query']) ? e($_GET['search_query']) : ''; ?>">
+            <form action="<?php echo url('companies'); ?>" method="GET" style="width: 100%;">
+                <md-outlined-text-field
+                    style="width: 100%;"
+                    label="<?php echo e(trans('search_placeholder')); ?>"
+                    name="search_query"
+                    id="search-input"
+                    value="<?php echo isset($_GET['search_query']) ? e($_GET['search_query']) : ''; ?>">
+                </md-outlined-text-field>
             </form>
             <div id="search-suggestions-container"></div>
         </div>
@@ -64,10 +83,10 @@ $currentAction = $view_data['current_action_resolved'] ?? '';
                     <div class="user-name"><?php echo e($currentUsername); ?></div>
                     <div class="user-role"><?php echo e(trans('user_role_display', ['role' => $currentUserRole])); ?></div>
                 </div>
-                <a href="<?php echo url('logout'); ?>" class="button button-outline button-small"><?php echo e(trans('logout')); ?></a>
+                <md-outlined-button style="width: 100%; margin-top: 5px;" href="<?php echo url('logout'); ?>"><?php echo e(trans('logout')); ?></md-outlined-button>
             <?php else: ?>
-                <a href="<?php echo url('login'); ?>" class="button button-primary button-small <?php echo $currentPage === 'login' ? 'active' : ''; ?>"><?php echo e(trans('login')); ?></a>
-                <a href="<?php echo url('register'); ?>" class="button button-outline button-small <?php echo $currentPage === 'register' ? 'active' : ''; ?>"><?php echo e(trans('register')); ?></a>
+                <md-filled-button style="width: 100%; margin-top: 5px;" href="<?php echo url('login'); ?>"><?php echo e(trans('login')); ?></md-filled-button>
+                <md-outlined-button style="width: 100%; margin-top: 5px;" href="<?php echo url('register'); ?>"><?php echo e(trans('register')); ?></md-outlined-button>
             <?php endif; ?>
         </div>
     </aside>


### PR DESCRIPTION
Integrates Material Web components as a Proof of Concept.

Key changes include:
- Added Material Web CDN for component and typography loading in header.php.
- Updated login form (templates/auth/login_form.php) to use md-outlined-text-field and md-filled-button.
- Updated company list page (templates/companies/index.php) action buttons and load more button to use MWC equivalents.
- Updated header/sidebar (templates/layout/header.php) search to md-outlined-text-field and footer buttons to MWC equivalents.
- Investigated button border radius customization and applied a 4dp radius (via --md-sys-shape-corner-extra-small) to the login button as an example.

This PoC provides a foundation for potential full-site integration of Material Web, pending further planning for build system setup and comprehensive component replacement.